### PR TITLE
Allow Queue Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/guratr/nova-command-runner.svg?style=flat)](https://packagist.org/packages/guratr/nova-command-runner)
 
 This [Nova](https://nova.laravel.com) tool lets you:
-- run artisan commands
+- run & queue artisan commands
 - specify options for commands
 - get command result
 - view commands history
@@ -43,8 +43,9 @@ php artisan vendor:publish --provider="Guratr\CommandRunner\ToolServiceProvider"
 Add your commands to config/nova-command-runner.php
 
 Available options:
-- run : command to run (E.g. route:cache)
-- options : arrary of options for command (e.g. ['--allow' => ['127.0.0.1']])  
+- run : command to run (e.g. `route:cache`)
+- options : array of options for command (e.g. `['--allow' => ['127.0.0.1']]`)  
+- queue : boolean (will use default settings when true) or array (e.g. `['connection' => 'database', 'queue' => 'default']`)
 - type : button class (primary, secondary, success, danger, warning, info, light, dark, link) 
 - group: Group name (optional)
 

--- a/config/nova-command-runner.php
+++ b/config/nova-command-runner.php
@@ -2,7 +2,9 @@
 
 return [
     'commands' => [
-        /*'Route cache'      => ['run' => 'route:cache', 'type' => 'info', 'group' => 'Cache'],
+        /*
+
+        'Route cache'      => ['run' => 'route:cache', 'type' => 'info', 'group' => 'Cache'],
         'Config cache'     => ['run' => 'config:cache', 'type' => 'info', 'group' => 'Cache'],
         'View cache'       => ['run' => 'view:cache', 'type' => 'info', 'group' => 'Cache'],
 
@@ -11,7 +13,12 @@ return [
         'View clear'      => ['run' => 'view:clear', 'type' => 'warning', 'group' => 'Clear Cache'],
 
         'Up'   => ['run' => 'up', 'type' => 'success', 'group' => 'Maintenance'],
-        'Down' => ['run' => 'down', 'options' => ['--allow' => ['127.0.0.1']], 'type' => 'dark', 'group' => 'Maintenance'],*/
+        'Down' => ['run' => 'down', 'options' => ['--allow' => ['127.0.0.1']], 'type' => 'dark', 'group' => 'Maintenance'],
+
+        'Queue default'   => ['run' => 'custom:default', 'queue' => true, 'type' => 'info', 'group' => 'Queue'],
+        'Queue custom'   => ['run' => 'custom:something', 'queue' => ['connection' => 'database', 'queue' => 'default'], 'type' => 'info', 'group' => 'Queue'],
+
+        */
     ],
     'history'  => 10,
 ];

--- a/src/Http/Controllers/CommandsController.php
+++ b/src/Http/Controllers/CommandsController.php
@@ -13,20 +13,21 @@ class CommandsController
     {
         $commands = config('nova-command-runner.commands');
         $command = $commands[$index] ?? null;
+
         if (!$command) {
             return ['status' => false, 'result' => 'Command not found!'];
         }
 
         $start = microtime(true);
+
         try {
-            $buffer = new \Symfony\Component\Console\Output\BufferedOutput();
-            \Artisan::call($command['run'], $command['options'] ?? [], $buffer);
-            $result = $buffer->fetch();
+            $result = $this->execute($command);
             $status = true;
         } catch (\Exception $exception) {
             $result = $exception->getMessage();
             $status = false;
         }
+
         $duration = microtime(true) - $start;
 
         if ($historyLength = config('nova-command-runner.history')) {
@@ -44,5 +45,26 @@ class CommandsController
         }
 
         return ['status' => $status, 'result' => $result];
+    }
+
+    protected function execute($command)
+    {
+        $buffer = new \Symfony\Component\Console\Output\BufferedOutput();
+
+        if(!($command['queue'] ?? false)) {
+            \Artisan::call($command['run'], $command['options'] ?? [], $buffer);
+            return $buffer->fetch();
+        }
+
+        ['connection' => $connection, 'queue' => $queue] = array_merge(
+            ['connection' => config('queue.default'), 'queue' => 'default'],
+            is_array($command['queue']) ? $command['queue'] : []
+        );
+
+        \Artisan::queue($command['run'], $command['options'] ?? [], $buffer)
+            ->onConnection($connection)
+            ->onQueue($queue);
+
+        return $buffer->fetch();
     }
 }


### PR DESCRIPTION
This PR adds the possibility to [queue Artisan commands](https://laravel.com/docs/master/artisan#programmatically-executing-commands), which is sometimes necessary for heavy commands that could exceed the API endpoint's timeout.